### PR TITLE
adjust-timestamp example

### DIFF
--- a/exercises/adjust_timestamp.md
+++ b/exercises/adjust_timestamp.md
@@ -1,0 +1,113 @@
+# Adjust timestamp
+
+Pymor provides `adjust_timestamp` parameter to adjust the timestamps in the cmorized datasets.
+
+Possible values this parameter accepts:
+
+  - named arguments: `first`, `last`, `mid`
+  - floating number: between `0.0` and `1.0`
+  - Literal offset: `14D`, `30D`
+ 
+If `adjust_timestamp` is not provided in the yaml file, the default is `first`.
+
+The floating number represent the offset as scaled values for `approx_interval` defined in the CMIP table.
+
+---
+
+For the exercise, we wanna see how this parameter influences the timestamps.
+
+Exercise folder: `./adjust_timestamp`
+
+Data used in the exercise has the following timestamps
+
+```shell
+cdo -s showtimestamp ../data/CO2f_fesom_mon_30010101.nc | xargs -n1 echo
+3001-01-16T23:59:59
+3001-02-15T11:59:59
+3001-03-16T23:59:59
+3001-04-16T11:59:59
+3001-05-16T23:59:59
+3001-06-16T11:59:59
+3001-07-16T23:59:59
+3001-08-16T23:59:59
+3001-09-16T11:59:59
+3001-10-16T23:59:59
+3001-11-16T11:59:59
+3001-12-16T23:59:59
+```
+
+
+# Exercise
+
+
+1. To get middle-of-the-month timestamps in the cmorized data, what value is used for `adjust_timestamp`
+
+   Is it `mid` or `14D`?
+
+   <details>
+      <summary>Solution</summary>
+  
+      - setting `adjust_timestamp: mid`, timestamps look like this:
+      ```shell
+      3001-01-15T12:00:00
+      3001-02-14T00:00:00
+      3001-03-15T12:00:00
+      3001-04-15T00:00:00
+      3001-05-15T12:00:00
+      3001-06-15T00:00:00
+      3001-07-15T12:00:00
+      3001-08-15T12:00:00
+      3001-09-15T00:00:00
+      3001-10-15T12:00:00
+      3001-11-15T00:00:00
+      3001-12-15T12:00:00
+      ```
+  
+      - setting `adjust_timestamp: 14D`, timestamps look like this:
+      ```shell
+      3001-01-15T00:00:00
+      3001-02-15T00:00:00
+      3001-03-15T00:00:00
+      3001-04-15T00:00:00
+      3001-05-15T00:00:00
+      3001-06-15T00:00:00
+      3001-07-15T00:00:00
+      3001-08-15T00:00:00
+      3001-09-15T00:00:00
+      3001-10-15T00:00:00
+      3001-11-15T00:00:00
+      3001-12-15T00:00:00
+      ```
+
+   </details>
+
+2. If `adjust_timestamp` is ommited from yaml file, how does the timestamps look like in the cmorized data.
+ 
+   <details>
+      <summary>Solution</summary>
+
+      - timestamps look as follows:
+      ```shell
+      3001-01-01T00:00:00
+      3001-02-01T00:00:00
+      3001-03-01T00:00:00
+      3001-04-01T00:00:00
+      3001-05-01T00:00:00
+      3001-06-01T00:00:00
+      3001-07-01T00:00:00
+      3001-08-01T00:00:00
+      3001-09-01T00:00:00
+      3001-10-01T00:00:00
+      3001-11-01T00:00:00
+      3001-12-01T00:00:00
+      ```
+      
+   </details>
+
+# Workflow
+
+1. In terminal, change into `./adjust_timestamp/` directory
+2. Edit `adjust-timestamp-example.yaml` file as necessary.
+3. Submit the job to slurm schedular. `sbatch pymorize.slurm`
+4. Load `cdo` into environment (if not already loaded) `module load cdo`
+5. Use `cdo` to investigate the timestamp in a file `cdo -s showtimestamp <filename>.nc`

--- a/exercises/adjust_timestamp/adjust-timestamp-example.yaml
+++ b/exercises/adjust_timestamp/adjust-timestamp-example.yaml
@@ -1,16 +1,16 @@
 general:
-  name: "units-example"
+  name: "adjust-timestamp-example"
   cmor_version: "CMIP6"
   mip: "CMIP"
-  CMIP_Tables_Dir: "/work/ab0995/a270243/pymorize/cmip6-cmor-tables/Tables"
-  CV_Dir: "/work/ab0995/a270243/pymorize/cmip6-cmor-tables/CMIP6_CVs"
-pymorize:
+  CMIP_Tables_Dir: "/work/ab0995/a270243/pymor/cmip6-cmor-tables/Tables"
+  CV_Dir: "/work/ab0995/a270243/pymor/cmip6-cmor-tables/CMIP6_CVs"
+pymor:
   # parallel: True
   warn_on_no_rule: False
   use_flox: True
   dask_cluster: "slurm"
   dask_cluster_scaling_mode: fixed
-  fixed_jobs: 12
+  fixed_jobs: 1
 rules:
   - name: fgco2
     inputs:
@@ -18,8 +18,9 @@ rules:
         pattern: CO2f_fesom_mon_.*nc
     cmor_variable: fgco2
     model_variable: CO2f
-    # adjust_timestamp options: first, middle, last, literal offset like 14days,
+    # adjust_timestamp options: first, middle, last, literal offset like 14D,
     # or floating point number between 0 and 1.
+    # MODIFY THIS PARAMETER
     adjust_timestamp: first
     grid_file: /pool/data/AWICM/FESOM1/MESHES/core/griddes.nc
     mesh_path: /pool/data/AWICM/FESOM1/MESHES/core
@@ -43,7 +44,7 @@ distributed:
 # SLURM-specific settings for launching workers
 jobqueue:
   slurm:
-    name: pymorize-worker
+    name: pymor-worker
     queue: compute # SLURM queue/partition to submit jobs
     account: ab0246 # SLURM project/account name
     cores: 4 # Number of cores per worker

--- a/exercises/adjust_timestamp/pymorize.slurm
+++ b/exercises/adjust_timestamp/pymorize.slurm
@@ -9,7 +9,11 @@ export PREFECT_SERVER_API_HOST=0.0.0.0
 # For more info about Prefect caching, see:
 # https://docs-3.prefect.io/v3/develop/settings-ref#local-storage-path
 export PREFECT_RESULTS_LOCAL_STORAGE_PATH=/scratch/a/${USER}/prefect
-loadconda
-conda activate pymorize
+
+#loadconda
+module load python3
+source $(conda info --base)/etc/profile.d/conda.sh
+conda activate pymor
 prefect server start -b
 time pymorize process adjust-timestamp-example.yaml
+prefect server stop


### PR DESCRIPTION
closes #6 

- [ ]  exercise description
- [ ]  yaml file
- [ ]  slurm script
- [ ]  supporting data

Supporting data is available on the Levante at `/work/ab0995/a270243/pymor_workshop/exercises/data`.
Not sure if that is the ideal place or needed to be relocated somewhere else.