### PR TITLE
old package name does not work anymore in pipelines

### DIFF
--- a/exercises/custom_functions/wo_cellarea.py
+++ b/exercises/custom_functions/wo_cellarea.py
@@ -20,8 +20,8 @@ Step.2 Apply cell_area calculations
 
 import xarray as xr
 
-import pymor.fesom_1p4
-from pymor.std_lib.units import ureg
+import pycmor.fesom_1p4
+from pycmor.std_lib.units import ureg
 
 
 def nodes_to_levels(data, rule):
@@ -31,7 +31,7 @@ def nodes_to_levels(data, rule):
             "Set `mesh_path` path in yaml config."
             "Required for converting nodes to levels"
         )
-    return pymor.fesom_1p4.nodes_to_levels(data, rule)
+    return pycmor.fesom_1p4.nodes_to_levels(data, rule)
 
 
 def weight_by_cellarea_and_density(data, rule):

--- a/exercises/custom_functions/wo_cellarea.yaml
+++ b/exercises/custom_functions/wo_cellarea.yaml
@@ -4,7 +4,7 @@ general:
   mip: "CMIP"
   CMIP_Tables_Dir: "../../cmip6-cmor-tables/Tables"
   CV_Dir: "../../cmip6-cmor-tables/CMIP6_CVs"
-pymor:
+pycmor:
   # parallel: True
   warn_on_no_rule: False
   use_flox: True
@@ -14,7 +14,7 @@ pymor:
 rules:
   - name: cellarea_wo
     inputs:
-      - path: ../data
+      - path: ../../data
         pattern: wo_fesom_.*nc
     cmor_variable: wmo
     model_variable: wo
@@ -32,17 +32,17 @@ rules:
 pipelines:
   - name: default
     steps:
-      - "pymor.core.gather_inputs.load_mfdataset"
-      - "pymor.std_lib.generic.get_variable"
+      - "pycmor.core.gather_inputs.load_mfdataset"
+      - "pycmor.std_lib.generic.get_variable"
       - "script://wo_cellarea.py:nodes_to_levels"
-      - "pymor.std_lib.time_average"
+      - "pycmor.std_lib.time_average"
       - "script://wo_cellarea.py:weight_by_cellarea_and_density"
-      - "pymor.std_lib.units.handle_unit_conversion"
-      - "pymor.std_lib.setgrid.setgrid"
-      - "pymor.std_lib.global_attributes.set_global_attributes"
-      - "pymor.std_lib.generic.trigger_compute"
-      - "pymor.std_lib.generic.show_data"
-      - "pymor.std_lib.files.save_dataset"
+      - "pycmor.std_lib.units.handle_unit_conversion"
+      - "pycmor.std_lib.setgrid.setgrid"
+      - "pycmor.std_lib.global_attributes.set_global_attributes"
+      - "pycmor.std_lib.generic.trigger_compute"
+      - "pycmor.std_lib.generic.show_data"
+      - "pycmor.std_lib.files.save_dataset"
 # Settings for using dask-distributed
 distributed:
   worker:


### PR DESCRIPTION
In yaml file there are still some references to old package name (`pymor`). This old name does not work in pipelines defined in yaml or if used in custom scripts. This fix renames those references to `pycmor`